### PR TITLE
Vision: call inherited BListView::MouseDown method

### DIFF
--- a/src/Names.h
+++ b/src/Names.h
@@ -69,12 +69,12 @@ public:
 	void ClearList();
 
 private:
-	bool fTracking;
-
 	BPopUpMenu* fMyPopUp;
 	BMenu* fCTCPPopUp;
 	int32 fLastSelected, fLastButton, fCurrentindex;
 	Theme* fActiveTheme;
+	bool fTracking;
+	bool fMouseDownHandled;
 };
 
 #endif

--- a/src/NotifyList.cpp
+++ b/src/NotifyList.cpp
@@ -135,6 +135,8 @@ void NotifyList::MouseDown(BPoint myPoint)
 			}
 		}
 	}
+
+	BListView::MouseDown(myPoint);
 }
 
 void NotifyList::BuildPopUp()

--- a/src/WindowList.cpp
+++ b/src/WindowList.cpp
@@ -233,6 +233,8 @@ void WindowList::MouseDown(BPoint myPoint)
 			}
 		}
 	}
+
+	BListView::MouseDown(myPoint);
 }
 
 void WindowList::KeyDown(const char*, int32)


### PR DESCRIPTION
NotifyList::MouseDown and WindowList::MouseDown needed to call into
BListView::MouseDown unconditionally.

NamesView::MouseDown is handling the click event and selection
itself sometimes so the fix is to only call BListView::MouseUp
if we also called BListView::MouseDown.

Fixes Vision bug #32
Fixes Haiku bug #14264